### PR TITLE
Remove callback when drawing button if already present

### DIFF
--- a/src/main/java/github/ankyl/castscreen/CastScreenActivity.java
+++ b/src/main/java/github/ankyl/castscreen/CastScreenActivity.java
@@ -114,6 +114,11 @@ public abstract class CastScreenActivity extends AppCompatActivity {
         mAppId = appId;
 
         mRouter = MediaRouter.getInstance(getApplicationContext());
+
+        // Remove existing callback if present
+        if(mCallback != null)
+            mRouter.removeCallback(mCallback);
+
         mCallback = new MediaRouterCallback();
         mRouter.addCallback(mSelector, mCallback, MediaRouter.CALLBACK_FLAG_REQUEST_DISCOVERY);
     }


### PR DESCRIPTION
In our application we use fragments with a main activity. To display the chromecast button we write **onCreateOptionsMenu** as instructed, but changing the frament calls again **prepareCastButton** duplicating the callback (and losing reference of it). 

So if a callback is already present we first remove the existing one, to avoid calling serveral times **MediaRouterCallback**, since this creates the CastScreenService several times, crashing the application.

This patch solves issue #4 